### PR TITLE
Start of sphinx integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,22 @@ matrix:
       env: BUILD_DOCS=1
 
 install:
-  # Install, configure conda
+  # pytmc
   - pip install Jinja2 lxml
   - pip install git+https://github.com/slaclab/pytmc.git@v2.1.0
   - pip install git+https://github.com/epicsdeb/pypdb.git
+
+  # docs
+  - pip install sphinx recommonmark
 
 script:
   - |
     find plc -name '*.tsproj' -print0 | 
         while IFS= read -r -d '' tsproj; do 
             pytmc pragmalint --verbose "$tsproj";
+            pytmc summary --all --code "$tsproj" > docs/source/$(basename $tsproj).md;
         done
+
+  - pushd docs
+  - make html
+  - popd

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,59 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'PLC_Project'
+copyright = '2019, SLAC National Accelerator Laboratory'
+author = 'SLAC National Accelerator Laboratory'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'recommonmark',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.txt': 'markdown',
+    '.md': 'markdown',
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,22 @@
+.. PLC_Project documentation master file, created by
+   sphinx-quickstart on Thu Sep  5 13:10:55 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to PLC_Project's documentation!
+=======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+   :glob:
+
+   *
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`


### PR DESCRIPTION
Adds/Notes
* Basic sphinx config
   - includes `recommonmark`, necessary for parsing the `md`-like output of `pytmc summary`
* `:glob:` directive and `*` in the toctree means we don't need to write `index.rst` ourselves

Stuff we need to think about:
* Build the docs integration?
* Summary output is somewhat ugly, but that can always be improved down the line
* Add list of records and/or `pytmc db` output
* Docs have project name as `PLC_Project`, which isn't correct
   - Do we just require the project to customize the conf.py, or can we automatically set this appropriately?
* Do we really need to respect the `BUILD_DOCS` env var?